### PR TITLE
dependency graph now allows for remote dependencies

### DIFF
--- a/community/cloud-foundation/src/cloud_foundation_toolkit/actions.py
+++ b/community/cloud-foundation/src/cloud_foundation_toolkit/actions.py
@@ -15,6 +15,7 @@
 """ Deployment Actions """
 
 import glob
+import os.path
 import sys
 
 from apitools.base.py import exceptions as apitools_exceptions
@@ -34,38 +35,35 @@ ACTION_MAP = {
     'update': {'preview': 'preview'}
 }
 
+def check_file(config):
+    extensions = ['.yaml', '.yml', '.jinja']
+    for ext in extensions:
+        if ext == config[-len(ext):]:
+            return True
+    return False
 
 def get_config_files(config):
-    """ Build a list of config files """
+    """ Build a list of config files
+    List could have files directory or yaml strings
 
-    config_list = config
-    dir_config_list = []
+    Args(list): List of configs. Each item can be a file, a directory,
+        or a yaml string
 
-    # Can be multiple files or directories
-    for config_args in config:
+    Returns: A list of config files or strings
+    """
 
-        # Try to search as a directory
-        files = glob.glob(config_args + '/*')
+    config_files = []
 
-        if files:
-            # Support only *.yaml, *.yml and *.jinja files
-            tmp_list = [
-                f for f in files if '.yaml' in f or '.yml' in f or '.jinja' in f
-            ]
-            dir_config_list.extend(tmp_list)
-
-            LOG.debug(
-                'Found config config files %s in directory %s',
-                tmp_list,
-                config_args
+    for conf in config:
+        if os.path.isdir(conf):
+            config_files.extend(
+                [f for f in glob.glob(conf + '/*') if check_file(f)]
             )
+        else:
+            config_files.append(conf)
 
-    if dir_config_list:
-        config_list = dir_config_list
-
-    LOG.debug('Config files %s', config_list)
-
-    return config_list
+    LOG.debug('Config files %s', config_files)
+    return config_files
 
 
 def execute(args):

--- a/community/cloud-foundation/src/cloud_foundation_toolkit/dm_utils.py
+++ b/community/cloud-foundation/src/cloud_foundation_toolkit/dm_utils.py
@@ -3,6 +3,7 @@ import io
 import re
 from six.moves.urllib.parse import urlparse
 
+from apitools.base.py import exceptions as apitools_exceptions
 from googlecloudsdk.api_lib.deployment_manager import dm_base
 from ruamel.yaml import YAML
 
@@ -31,12 +32,15 @@ API = DM_API()
 
 
 def get_deployment(project, deployment):
-    return API.client.deployments.Get(
-        API.messages.DeploymentmanagerDeploymentsGetRequest(
-            project=project,
-            deployment=deployment
+    try:
+        return API.client.deployments.Get(
+            API.messages.DeploymentmanagerDeploymentsGetRequest(
+                project=project,
+                deployment=deployment
+            )
         )
-    )
+    except apitools_exceptions.HttpNotFoundError as _:
+        return None
 
 
 def get_manifest(project, deployment):


### PR DESCRIPTION
With this change, if a dependency is not found in the list of configs provided in the command line, it checks if the dependency exists in DM